### PR TITLE
Rename plugin category

### DIFF
--- a/FortnitePorting.uplugin
+++ b/FortnitePorting.uplugin
@@ -4,7 +4,7 @@
 	"VersionName": "1.0.8",
 	"FriendlyName": "FortnitePorting",
 	"Description": "Unreal Server for Fortnite Porting",
-	"Category": "Import",
+	"Category": "Importers",
 	"CreatedBy": "Half",
 	"CreatedByURL": "https://github.com/halfuwu",
 	"DocsURL": "",


### PR DESCRIPTION
Rename the plugin category from "Import" to "Importers" to be more in line with both UnrealPSKPSA, as well as the UnrealEngine plugin categories